### PR TITLE
Python modernization continuation

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -47,7 +47,6 @@ jobs:
           virtualenv -p python3 venv
           source venv/bin/activate
           pip install .
-          sudo install -m 0755 build/bin/diffkemp /usr/bin/diffkemp
       - name: Development build of DiffKemp
         if: ${{ matrix.build-type == 'development' }}
         run: |
@@ -55,7 +54,9 @@ jobs:
           sudo ninja -C build
           virtualenv -p python3 venv
           source venv/bin/activate
-          pip install -e .
+          # Installing dependencies
+          pip install .
+          pip uninstall -y diffkemp
       - name: Check by building and comparing make-based project
         run: |
           source venv/bin/activate
@@ -70,8 +71,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v10
       - name: Build DiffKemp
         run: >
-          nix develop . --command bash -c
-          "pip install cffi &&
+          nix develop . --command bash -c "
            cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug &&
            ninja -C build"
       - name: Check by building and comparing make-based project

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -22,8 +22,15 @@ jobs:
         include:
           - build-type: release
             diffkemp-bin: diffkemp
+            build-dir: build
           - build-type: development
             diffkemp-bin: build/bin/diffkemp
+            build-dir: build
+          # Development build with custom build directory and disabled CFFI
+          - build-type: development
+            diffkemp-bin: my-build-dir/bin/diffkemp
+            build-dir: my-build-dir
+            compare-options: --disable-simpll-ffi
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -42,27 +49,27 @@ jobs:
       - name: Release build and install of DiffKemp
         if: ${{ matrix.build-type == 'release' }}
         run: |
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release
-          sudo ninja -C build install
+          cmake -S . -B ${{ matrix.build-dir }} -GNinja -DCMAKE_BUILD_TYPE=Release
+          sudo ninja -C ${{ matrix.build-dir }} install
           virtualenv -p python3 venv
           source venv/bin/activate
           pip install .
       - name: Development build of DiffKemp
         if: ${{ matrix.build-type == 'development' }}
         run: |
-          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug
-          sudo ninja -C build
+          cmake -S . -B ${{ matrix.build-dir }} -GNinja -DCMAKE_BUILD_TYPE=Debug
+          sudo ninja -C ${{ matrix.build-dir }}
           virtualenv -p python3 venv
           source venv/bin/activate
           # Installing dependencies
-          pip install .
+          SIMPLL_BUILD_DIR="${{matrix.build-dir}}" pip install .
           pip uninstall -y diffkemp
       - name: Check by building and comparing make-based project
         run: |
           source venv/bin/activate
           ${{matrix.diffkemp-bin}} build tests/testing_projects/make_based/ old-snapshot
           ${{matrix.diffkemp-bin}} build tests/testing_projects/make_based/ new-snapshot
-          ${{matrix.diffkemp-bin}} compare old-snapshot new-snapshot
+          ${{matrix.diffkemp-bin}} compare ${{matrix.compare-options}} old-snapshot new-snapshot
 
   nix-development-build:
     runs-on: ubuntu-latest

--- a/diffkemp/diffkemp.in
+++ b/diffkemp/diffkemp.in
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
+import os
 import sys
 
 if __name__ == "__main__":
     sys.path.append("${CMAKE_BINARY_DIR}/diffkemp/simpll")
     sys.path.append("${CMAKE_SOURCE_DIR}")
+    os.environ["SIMPLL_BUILD_DIR"] = "${CMAKE_BINARY_DIR}"
     from diffkemp.cli import run_from_cli
     run_from_cli()

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -67,6 +67,10 @@ def build_c_project(args):
                                               else "0")
     }
     environment.update(os.environ)
+    # Passing down the PYTHONPATH variable to be able to run CC_WRAPPER
+    # even in development mode (without installation of DiffKemp).
+    # Without this the wrapper could not import from DiffKemp package.
+    environment["PYTHONPATH"] = ":".join(sys.path)
 
     # Determine make args
     make_cc_setting = 'CC="{}"'.format(cc_wrapper)

--- a/diffkemp/simpll/simpll_build.py
+++ b/diffkemp/simpll/simpll_build.py
@@ -31,6 +31,9 @@ def get_root_dir(path, is_develop_build):
 
 ffibuilder = FFI()
 location = os.path.dirname(os.path.abspath(__file__))
+# We can get the project root directory by recognizing whether the script is
+# ran manually or by the `setuptools`. The `setuptools` build calls this script
+# with additional arguments (_in_process.py bdist_wheel --dist-info-dir ...).
 root_dir = get_root_dir(location, is_develop_build=(len(sys.argv) == 1))
 path_to_ffi_header = "diffkemp/simpll/library/FFI.h"
 

--- a/diffkemp/simpll/simpll_lib.py
+++ b/diffkemp/simpll/simpll_lib.py
@@ -1,7 +1,11 @@
+"""Module exports:
+- lib - loaded SimpLL library (contains callable references to the C functions
+  declared in `library/FFI.h`),
+- ffi - interface for defining C types/functions and manipulating C data in
+  Python.
+"""
+
 # Dynamically import the SimpLL C extension module.
-# First try to import from the current build directory (to allow multiple
-# parallel local builds).
-# If that fails, import from the default location.
 _simpll = __import__("_simpll")
 lib = _simpll.lib
 ffi = _simpll.ffi

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,8 +68,10 @@ nix develop .#diffkemp-llvm14
 This will enter a development shell with all DiffKemp dependencies
 pre-installed. You can then follow the [standard build
 instructions](#build) to build and install DiffKemp. The only
-difference is that it is not possible to run `pip install` inside Nix shell
-(because of the way Nix works). Thus, you have to use our generated executables.
+difference is that you do not need to install the Python dependencies because
+they are already preinstalled.
+
+The generated executable is then located in `BUILD_DIR/bin/diffkemp`.
 
 We also provide a special Nix environment for retrieving and preparing kernel
 versions necessary for running [regression tests](#python-tests)
@@ -123,7 +125,6 @@ To build DiffKemp, use the following commands:
 ```sh
 cmake -S . -B build -GNinja -DBUILD_VIEWER=On
 ninja -C build
-pip install -e . # In case of Nix use setuptoolsShellHook instead
 ```
 
 - `-DBUILD_VIEWER=On`: This flag will install packages and build the result
@@ -131,21 +132,21 @@ pip install -e . # In case of Nix use setuptoolsShellHook instead
   want to use `-DBUILD_VIEWER=Off` instead.
 
 If you make changes to the SimpLL library, you will need to rebuild it by
-running `ninja -C build`. We are using [CFFI](https://cffi.readthedocs.io/en/stable/)
-for accessing the library from the Python. The CFFI is not rebuilt by default,
-so even if you rebuild the library, the changes will not be visible when running
-`diffkemp compare ...`. Currently, you have multiple options to overcome this:
+running `ninja -C <BUILD_DIR>`. We are using [CFFI](https://cffi.readthedocs.io/en/stable/)
+for accessing the library from the Python.
 
-1. Use `diffkemp compare --disable-simpll-ffi ...` which will run SimpLL
-  through a binary instead of the CFFI.
-2. On some OS distributions, it is enough to run `pip install -e .` again.
-3. Another option is to to run `rm build/_simpll.abi3.so` and then run `cmake`
-  again with `-DSIMPLL_REBUILD_BINDINGS=On` flag. After this, when you make
-  changes to the SimpLL library, running `ninja -C build` should be enough and
-  it should rebuild the CFFI, and the changes should be visible when running
-  `diffkemp compare ...`.
-  (Note: This does not seems to be working in the [Nix development environment](#nix-as-development-environment),
-  so use option 1 instead.)
+To be able to use DiffKemp, it is also necessary to **install Python dependencies**,
+you can install them:
+
+- by running `pip install . && pip uninstall -y diffkemp` or
+- install them manually by using `pip install <DEPENDENCIES>` (dependencies are
+  specified in `packages` field in `pyproject.toml` file).
+
+> [!NOTE]
+> If you used different than the default build directory (`build`) and want to
+> use `pip install .` for installing python dependencies, then you need to
+> specify the build directory when running `pip` by using
+> `SIMPLL_BUILD_DIR=<BUILD_DIR> pip install .`.
 
 ## Coding style
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ Currently, DiffKemp runs on Linux and needs the following software installed:
 - Clang and LLVM (supported versions are 9 - 17)
 * Z3 SMT solver and its C++ bindings (packages `z3` and `z3-devel` in Fedora)
 - Python 3 with CFFI (package `python3-cffi` in Fedora and Debian)
-- Python packages from `requirements.txt` (run `pip install -r requirements.txt`)
+- Python packages from `packages` field in `pyproject.toml` (automatically installed when running `pip install .`)
 - CScope (when comparing versions of the Linux kernel)
 - GoogleTest (gtest) for running the C++ tests (can be vendored by using
   `-DVENDOR_GTEST=On` in the `cmake` command)
@@ -29,8 +29,7 @@ Currently, DiffKemp runs on Linux and needs the following software installed:
 
 ```sh
 # Installation of dependencies
-apt install -y cmake ninja-build llvm clang g++ libgtest-dev python3-pip python-is-python3 z3 z3-dev
-pip install -r requirements.txt # You may want to use it in virtual environment
+apt install -y cmake ninja-build llvm clang g++ libgtest-dev python3-pip python-is-python3 z3 libz3-dev python3-cffi
 # Installation of the result viewer dependencies (node, npm)
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 nvm install 20
@@ -40,8 +39,7 @@ nvm install 20
 
 ```sh
 # Installation of dependencies
-dnf install -y cmake ninja-build llvm-devel clang g++ python3-devel diffutils python3-pip gtest-devel z3 z3-devel
-pip install -r requirements.txt
+dnf install -y cmake ninja-build llvm-devel clang g++ python3-devel diffutils python3-pip gtest-devel z3 z3-devel python3-cffi python3-setuptools
 # Installation of the result viewer dependencies (node, npm)
 dnf install nodejs
 ```
@@ -53,30 +51,18 @@ dnf install nodejs
 > ensure DiffKemp uses correct version (e.g. by prefixing the PATH with path
 > to the LLVM binaries - `PATH="/usr/lib64/llvmXX/bin/:$PATH"`).
 
-## Building
+## Building and installation
 
-Build can be done by running:
+Build with installation can be done by running:
 
 ```sh
 cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_VIEWER=On
-ninja -C build
-pip install -e .
+ninja -C build install
+pip install .
 ```
-
-The DiffKemp binary is then located in `bin/diffkemp`.
 
 You can omit `-DBUILD_VIEWER=On` flag in `cmake` if you do not want to use the
 result viewer (dependencies won't be installed for that and the viewer won't be
 built).
-
-## Installation
-
-Optionally, you can install DiffKemp on the system using the following commands:
-
-```sh
-ninja -C build install
-pip install .
-install -m 0755 bin/diffkemp /usr/bin/diffkemp
-```
 
 Then you can use the `diffkemp` command from any location.

--- a/main.py
+++ b/main.py
@@ -1,3 +1,0 @@
-import os
-
-print(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/unit_tests/run_pytest_tests.py.in
+++ b/tests/unit_tests/run_pytest_tests.py.in
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
+import os
 import sys
 import pytest
 
 if __name__ == "__main__":
     sys.path.append("${CMAKE_BINARY_DIR}/diffkemp/simpll")
     sys.path.append("${CMAKE_SOURCE_DIR}")
+    os.environ["SIMPLL_BUILD_DIR"] = "${CMAKE_BINARY_DIR}"
     sys.exit(pytest.main([
         "${CMAKE_SOURCE_DIR}/tests",
         # Pass the CLI arguments to pytest


### PR DESCRIPTION
This PR continues https://github.com/diffkemp/diffkemp/pull/344 and tries to resolve comments on the PR. All comments should hopefully be resolved now:
- Docs are updated (including installation of Python dependencies),
- fixed building of DiffKemp when using a directory other than the default build directory by specifying `SIMPLL_BUILD_DIR`,
- other things -- see individual commits.

The preview of the changed documentation is available here <https://github.com/PLukas2018/diffkemp/tree/python-modernization-continuation/docs>.

To test the changes, I rerun the things mentioned in https://github.com/diffkemp/diffkemp/pull/344#pullrequestreview-2191337960 (when testing, I used a different build directory than the default to check the correct behaviour for it), and I did not find any problem.