### PR TITLE
SimpLL: Enable getting struct size from dbg record

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -516,11 +516,12 @@ int DifferentialFunctionComparator::cmpAllocs(const CallInst *CL,
         RETURN_WITH_LOG(1);
 
     // If the next instruction is a bitcast, compare its type instead
-    const Value *ValL =
-            isa<BitCastInst>(CL->getNextNode()) ? CL->getNextNode() : CL;
-    const Value *ValR =
-            isa<BitCastInst>(CR->getNextNode()) ? CR->getNextNode() : CR;
-
+    const auto *nextInstL = CL->getNextNode();
+    const auto *nextInstR = CR->getNextNode();
+    const bool isNextInstBitcastL = nextInstL && isa<BitCastInst>(nextInstL);
+    const bool isNextInstBitcastR = nextInstR && isa<BitCastInst>(nextInstR);
+    const Value *ValL = isNextInstBitcastL ? nextInstL : CL;
+    const Value *ValR = isNextInstBitcastR ? nextInstR : CR;
     // Retrieve type names and sizes
     TypeInfo TypeInfoL =
             getPointeeStructTypeInfo(ValL, &LayoutL, FnL->getName());

--- a/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
+++ b/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
@@ -156,13 +156,6 @@ void TestComparator::addCustomPatternSet(const CustomPatternSet *PatternSet) {
 DifferentialFunctionComparatorTest::DifferentialFunctionComparatorTest()
         : ::testing::Test() {
 
-// From LLVM 19 there is a new format of debug info, which we do not currently
-// support.
-#if LLVM_VERSION_MAJOR >= 19
-    ModL->convertFromNewDbgValues();
-    ModR->convertFromNewDbgValues();
-#endif
-
     // Create one function in each module for testing purposes.
     FL = Function::Create(FunctionType::get(Type::getVoidTy(CtxL), {}, false),
                           GlobalValue::ExternalLinkage,
@@ -418,8 +411,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpAllocs) {
     DIExpression *exprR = builderR.createExpression();
     DILocation *locL = DILocation::get(DSubL->getContext(), 0, 0, DSubL);
     DILocation *locR = DILocation::get(DSubR->getContext(), 0, 0, DSubR);
-    builderL.insertDbgValueIntrinsic(CL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(CR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(CL, varL, exprL, locL, CL);
+    builderR.insertDbgValueIntrinsic(CR, varR, exprR, locR, CR);
 
     ASSERT_EQ(DiffComp->testCmpAllocs(CL, CR), 0);
 
@@ -486,8 +479,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpAllocs) {
     exprR = builderR.createExpression();
     locL = DILocation::get(DSubL->getContext(), 0, 0, DSubL);
     locR = DILocation::get(DSubR->getContext(), 0, 0, DSubR);
-    builderL.insertDbgValueIntrinsic(CL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(CR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(CL, varL, exprL, locL, CL);
+    builderR.insertDbgValueIntrinsic(CR, varR, exprR, locR, CR);
     ASSERT_EQ(DiffComp->testCmpAllocs(CL, CR), 0);
 
     // Repeat the test again, but now with different structure types.
@@ -519,7 +512,7 @@ TEST_F(DifferentialFunctionComparatorTest, CmpAllocs) {
     PointerTypeR = builderR.createPointerType(StructTypeR, 64);
     varR = builderR.createAutoVariable(
             FunTypeR, "var", nullptr, 0, PointerTypeR);
-    builderR.insertDbgValueIntrinsic(CR, varR, exprR, locR, BBR);
+    builderR.insertDbgValueIntrinsic(CR, varR, exprR, locR, CR);
     ASSERT_EQ(DiffComp->testCmpAllocs(CL, CR), 1);
 }
 
@@ -622,8 +615,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpMemsets) {
     DIExpression *exprR = builderR.createExpression();
     DILocation *locL = DILocation::get(DSubL->getContext(), 0, 0, DSubL);
     DILocation *locR = DILocation::get(DSubR->getContext(), 0, 0, DSubR);
-    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, AllL);
+    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, AllR);
 
     ASSERT_EQ(DiffComp->testCmpMemset(CL, CR), -1);
 
@@ -643,8 +636,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpMemsets) {
                            ConstantInt::get(Type::getInt32Ty(CtxR), STyRSize)},
                           "",
                           BBR);
-    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, AllL);
+    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, AllR);
     ASSERT_EQ(DiffComp->testCmpMemset(CL, CR), 0);
 }
 
@@ -753,8 +746,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpMemsetsMultipleDebugMetadata) {
     DIExpression *exprR = builderR.createExpression();
     DILocation *locL = DILocation::get(DSubL->getContext(), 0, 0, DSubL);
     DILocation *locR = DILocation::get(DSubR->getContext(), 0, 0, DSubR);
-    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, AllR);
+    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, AllL);
 
     // Debug metadata describing var from the scope of memset function.
     DIFile *MemsetUnitL = builderL.createFile("memset", "stdlib");
@@ -770,9 +763,9 @@ TEST_F(DifferentialFunctionComparatorTest, CmpMemsetsMultipleDebugMetadata) {
     DILocalVariable *memsetVarR = builderR.createAutoVariable(
             MemsetTypeR, "__dest", nullptr, 0, MemsetPointerTypeR);
     builderL.insertDbgValueIntrinsic(
-            AllL, memsetVarL, builderL.createExpression(), locL, BBL);
+            AllL, memsetVarL, builderL.createExpression(), locL, AllL);
     builderR.insertDbgValueIntrinsic(
-            AllR, memsetVarR, builderR.createExpression(), locR, BBR);
+            AllR, memsetVarR, builderR.createExpression(), locR, AllR);
 
     ASSERT_EQ(DiffComp->testCmpMemset(CL, CR), 0);
 }
@@ -845,8 +838,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpMemsetsVoidPtrType) {
     DIExpression *exprR = builderR.createExpression();
     DILocation *locL = DILocation::get(DSubL->getContext(), 0, 0, DSubL);
     DILocation *locR = DILocation::get(DSubR->getContext(), 0, 0, DSubR);
-    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, AllL);
+    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, AllR);
 
     ASSERT_NE(DiffComp->testCmpMemset(CL, CR), 0);
 }
@@ -978,8 +971,8 @@ TEST_F(DifferentialFunctionComparatorTest, CmpMemsetsOfTypedef) {
     DIExpression *exprR = builderR.createExpression();
     DILocation *locL = DILocation::get(DSubL->getContext(), 0, 0, DSubL);
     DILocation *locR = DILocation::get(DSubR->getContext(), 0, 0, DSubR);
-    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, BBL);
-    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, BBR);
+    builderL.insertDbgValueIntrinsic(AllL, varL, exprL, locL, AllL);
+    builderR.insertDbgValueIntrinsic(AllR, varR, exprR, locR, AllR);
 
     ASSERT_EQ(DiffComp->testCmpMemset(CL, CR), 0);
 }


### PR DESCRIPTION
Fixes failing unit tests in LLVM 19.